### PR TITLE
Add simple Swift number guessing game

### DIFF
--- a/HelloWorld.swift
+++ b/HelloWorld.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+print("Hello, world!")

--- a/NumberGuess.swift
+++ b/NumberGuess.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+let number = Int.random(in: 1...100)
+var guess: Int? = nil
+
+print("Welcome to Guess the Number!")
+print("I'm thinking of a number between 1 and 100.")
+
+while guess != number {
+    print("Enter your guess:", terminator: " ")
+    if let line = readLine(), let value = Int(line) {
+        guess = value
+        if guess! < number {
+            print("Too low! Try again.")
+        } else if guess! > number {
+            print("Too high! Try again.")
+        } else {
+            print("Correct! The number was \(number).")
+        }
+    } else {
+        print("Please enter a valid integer.")
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-This is to test codex
+# Swift Samples
+
+This repository includes simple Swift examples for demonstration:
+
+- `HelloWorld.swift` prints a classic greeting.
+- `NumberGuess.swift` is a small text-based game where you guess a random number.
+
+## Running the examples
+
+Use the Swift interpreter to run the files:
+
+```bash
+swift HelloWorld.swift
+swift NumberGuess.swift
+```


### PR DESCRIPTION
## Summary
- add `NumberGuess.swift` implementing a small text-based guessing game
- update `README.md` with instructions for the new example

## Testing
- `swift HelloWorld.swift`
- `swiftc NumberGuess.swift -o NumberGuess`


------
https://chatgpt.com/codex/tasks/task_e_684816254ff0832e9132859f35756854