### PR TITLE
Add dice chat and prediction mechanic

### DIFF
--- a/DiceGame.swift
+++ b/DiceGame.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+func rollDie() -> Int {
+    return Int.random(in: 1...6)
+}
+
+/// Clear the screen with ANSI escape codes.
+func clearScreen() {
+    print("\u{001B}[2J\u{001B}[H", terminator: "")
+}
+
+/// ASCII art for dice faces.
+let diceArt: [Int: [String]] = [
+    1: [
+        "+-----+",
+        "|     |",
+        "|  o  |",
+        "|     |",
+        "+-----+"
+    ],
+    2: [
+        "+-----+",
+        "|o    |",
+        "|     |",
+        "|    o|",
+        "+-----+"
+    ],
+    3: [
+        "+-----+",
+        "|o    |",
+        "|  o  |",
+        "|    o|",
+        "+-----+"
+    ],
+    4: [
+        "+-----+",
+        "|o   o|",
+        "|     |",
+        "|o   o|",
+        "+-----+"
+    ],
+    5: [
+        "+-----+",
+        "|o   o|",
+        "|  o  |",
+        "|o   o|",
+        "+-----+"
+    ],
+    6: [
+        "+-----+",
+        "|o   o|",
+        "|o   o|",
+        "|o   o|",
+        "+-----+"
+    ]
+]
+
+func displayDice(_ value: Int) {
+    if let art = diceArt[value] {
+        for line in art { print(line) }
+    } else {
+        print("Rolled: \(value)")
+    }
+}
+
+func displayScores(player: Int, ai: Int) {
+    print("┌───────────────┐")
+    print("│  Scoreboard   │")
+    print("├─────┬─────────┤")
+    print(String(format: "│ You │ %3d    │", player))
+    print(String(format: "│ AI  │ %3d    │", ai))
+    print("└─────┴─────────┘")
+}
+
+/// Possible text for each die face.
+let faceMessages: [Int: [String]] = [
+    1: ["Oh no, snake eyes!", "A one means bust."],
+    2: ["Rolling a timid two.", "Two dots staring back."],
+    3: ["Triple threat with a three.", "A solid three."],
+    4: ["Four. Nice and even.", "A steady four."],
+    5: ["High five for a five!", "Five on the board."],
+    6: ["Six! Maximum roll.", "You hit the high six!"]
+]
+
+/// Random AI responses to short player messages.
+let aiReplies = [
+    "Good luck with that roll!",
+    "We'll see who wins this round.",
+    "Interesting strategy...",
+    "I'm not worried about your chances."
+]
+
+func messageForRoll(_ roll: Int) -> String {
+    return faceMessages[roll]?.randomElement() ?? ""
+}
+
+func aiReply() -> String {
+    return aiReplies.randomElement() ?? ""
+}
+
+let targetScore = 50
+var playerScore = 0
+var aiScore = 0
+
+print("Welcome to Dice Duel! First to \(targetScore) points wins.")
+
+while playerScore < targetScore && aiScore < targetScore {
+    clearScreen()
+    displayScores(player: playerScore, ai: aiScore)
+    // Player turn
+    var turnScore = 0
+    print("\nYour turn.")
+    playerTurn: while true {
+        print("Predict high (h) or low (l):", terminator: " ")
+        let guessInput = readLine()?.lowercased() ?? ""
+        let guessHigh = guessInput == "h"
+        print("Say something to the AI or press Enter to roll:", terminator: " ")
+        let chat = readLine() ?? ""
+        if !chat.isEmpty {
+            print("You: \(chat)")
+            print("AI: \(aiReply())")
+        }
+
+        let roll = rollDie()
+        let bonus = ((guessHigh && roll > 3) || (!guessHigh && roll <= 3)) ? 1 : 0
+        displayDice(roll)
+        print(messageForRoll(roll))
+        if bonus > 0 { print("Your prediction was correct! +1 bonus point.") }
+        if roll == 1 {
+            print("Bust! You lose your turn score.")
+            turnScore = 0
+            break playerTurn
+        } else {
+            turnScore += roll + bonus
+            print("Turn score: \(turnScore). Type 'r' to roll again or 'h' to hold:", terminator: " ")
+            if let choice = readLine()?.lowercased() {
+                if choice == "h" {
+                    playerScore += turnScore
+                    print("You hold. Total score now \(playerScore).")
+                    break playerTurn
+                } else if choice != "r" {
+                    print("Invalid input, rolling again by default.")
+                }
+            }
+        }
+    }
+
+    if playerScore >= targetScore { break }
+
+    // AI turn
+    turnScore = 0
+    print("\nAI's turn. Total score: \(aiScore).")
+    print("AI: \(aiReply())")
+    while true {
+        let roll = rollDie()
+        displayDice(roll)
+        print("AI rolled a \(roll). \(messageForRoll(roll))")
+        if roll == 1 {
+            print("AI busts and loses its turn score.")
+            turnScore = 0
+            break
+        } else {
+            turnScore += roll
+            // AI strategy: hold if turnScore >= 12 or it can win this turn
+            if turnScore >= 12 || aiScore + turnScore >= targetScore {
+                aiScore += turnScore
+                print("AI holds. Total score now \(aiScore).")
+                break
+            }
+        }
+    }
+}
+
+if playerScore >= targetScore {
+    print("\nCongratulations! You beat the AI with \(playerScore) points.")
+} else {
+    print("\nThe AI wins with \(aiScore) points. Better luck next time!")
+}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This repository includes simple Swift examples for demonstration:
 
 - `HelloWorld.swift` prints a classic greeting.
 - `NumberGuess.swift` is a small text-based game where you guess a random number.
+- `DiceGame.swift` pits you against an AI in a dice duel with optional chat
+  messages and a high/low prediction bonus.
+  It also draws simple ASCII dice and a scoreboard for a more visual
+  experience.
 
 ## Running the examples
 
@@ -12,4 +16,5 @@ Use the Swift interpreter to run the files:
 ```bash
 swift HelloWorld.swift
 swift NumberGuess.swift
+swift DiceGame.swift
 ```


### PR DESCRIPTION
## Summary
- update `DiceGame.swift` with random text for each die face
- let players chat with the AI and guess high/low for a bonus
- add ASCII dice and scoreboard UI
- describe new gameplay in README

## Testing
- `swift DiceGame.swift <<'EOF'
h
hello
h
hi
EOF`
- `swift DiceGame.swift <<'EOF'
h

h

h

EOF`


------
https://chatgpt.com/codex/tasks/task_e_68483fba1e40832e8b17ec2cd4992b99